### PR TITLE
Add build-ring command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ Add the Debian control file debian/DEBIAN/control
     Depends: {{depends}}
     Description: {{description}}
 
+Add the template for the changes file debian/DEBIAN/template.changes
+
+
+    Format: 1.8
+    Date: {{date}}
+    Source: {{name}} 
+    Binary: {{name}}
+    Architecture: all
+    Version: {{version}}
+    Distribution: demo
+    Maintainer: Lein <test@leindpkg.com>
+    Description: whatever description
+    Changes:
+     * new version system
+    Files:
+       {{md5}} {{size}} main important {{deb-file}}
+
 Build the Debian package.
 
     lein dpkg build

--- a/debian/DEBIAN/template.changes
+++ b/debian/DEBIAN/template.changes
@@ -1,0 +1,13 @@
+Format: 1.8
+Date: {{date}}
+Source: {{name}} 
+Binary: {{name}}
+Architecture: all
+Version: {{version}}
+Distribution: demo
+Maintainer: Lein <test@leindpkg.com>
+Description: whatever description
+Changes:
+ * new version system
+Files:
+   {{md5}} {{size}} main important {{deb-file}}

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
+                 [lein-ring "0.8.12"]
                  [org.apache.commons/commons-io "1.3.2"]]
   :eval-in-leiningen true
   :dpkg {:incremental "BUILD_NUMBER"}

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,11 @@
-(defproject lein-dpkg "0.1.3-SNAPSHOT"
+(defproject org.clojars.txominpelu/lein-dpkg "0.1.4-SNAPSHOT"
   :description "Leiningen plugin for the Debian package management system"
   :url "https://github.com/r0man/lein-dpkg"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [lein-ring "0.8.12"]
+                 [joda-time/joda-time "2.5"]
                  [org.apache.commons/commons-io "1.3.2"]]
   :eval-in-leiningen true
   :dpkg {:incremental "BUILD_NUMBER"}

--- a/src/leiningen/dpkg.clj
+++ b/src/leiningen/dpkg.clj
@@ -4,6 +4,7 @@
            [org.apache.commons.io FileUtils]
            java.io.File)
   (:require [clojure.java.io :refer [copy file]]
+            [leiningen.ring.uberjar :as ruberjar]
             [clojure.java.shell :refer [sh with-sh-dir]]
             [clojure.string :refer [blank? join replace]]
             [leiningen.clean :refer [delete-file-recursively]]
@@ -120,6 +121,17 @@
     (build-package)
     (rename-package)))
 
+(defn build-ring
+  "Build the Debian package for a ring project."
+  [project]
+  (doto project
+    (clean)
+    (ruberjar/uberjar)
+    (copy-uberjar)
+    (render-templates)
+    (build-package)
+    (rename-package)))
+
 (defn install
   "Install the Debian package."
   [project]
@@ -140,6 +152,7 @@
   [project & [command]]
   (case command
     "build" (build project)
+    "build-ring" (build-ring project)
     "clean" (clean project)
     "install" (install project)
     "purge" (purge project)

--- a/test/leiningen/dpkg_test.clj
+++ b/test/leiningen/dpkg_test.clj
@@ -22,6 +22,10 @@
   (doall (build project))
   (is (.exists (File. (deb-target-file project)))))
 
+(deftest test-build-changes
+  (doall (build project))
+  (is (.exists (File. (deb-target-changes-file project)))))
+
 (deftest test-clean
   (clean project)
   (is (not (.exists (File. (deb-target-dir project))))))


### PR DESCRIPTION
The build-ring allows to build ring-based leiningen projects.

The current limitation when building ring based projects is that the default uberjar command doesn't work (the main class is not specified).
